### PR TITLE
Split unsigned integer helper function to support padding of byte[] values

### DIFF
--- a/src/LibAsn.cs
+++ b/src/LibAsn.cs
@@ -202,19 +202,21 @@ namespace Gallagher.LibAsn
         // convenience helper for creating integers
         public static AsnObject Integer(int value) => new AsnObject(AsnTag.Simple.Integer, BitConverter.GetBytes(value));
 
+        // convenience helper for creating unsigned integers
+        // Note this will always require 4 bytes to encode even a single digit value, which is technically wrong.
+        // need to come back and make this work properly and add unit tests
+        public static AsnObject UnsignedInteger(uint value) => UnsignedInteger(BitConverter.GetBytes(value));
+
         // convenience helper for creating unsigned integers. Not particularly efficient but it'll do
-        public static AsnObject UnsignedInteger(uint value)
+        public static AsnObject UnsignedInteger(byte[] value)
         {
-            // Note this will always require 4 bytes to encode even a single digit value, which is technically wrong.
-            // need to come back and make this work properly and add unit tests
-            var bytes = BitConverter.GetBytes(value);
-            if ((bytes[0] & 0x80) != 0) // high bit is set on an unsigned integer which means this would be interpreted as a negative int
+            if ((value[0] & 0x80) != 0) // high bit is set on an unsigned integer which means this would be interpreted as a negative int
             {
-                var unsignedBytes = new byte[bytes.Length + 1]; // force a leading 0 byte
-                bytes.CopyTo(unsignedBytes, 1);
+                var unsignedBytes = new byte[value.Length + 1]; // force a leading 0 byte
+                value.CopyTo(unsignedBytes, 1);
                 return new AsnObject(AsnTag.Simple.Integer, unsignedBytes);
             }
-            return new AsnObject(AsnTag.Simple.Integer, bytes);
+            return new AsnObject(AsnTag.Simple.Integer, value);
         }
 
         // convenience helper for creating a UtcTime. Converts the time to UTC if it is not already.

--- a/tests/LibAsnTests/LibAsnTests.cs
+++ b/tests/LibAsnTests/LibAsnTests.cs
@@ -137,19 +137,6 @@ namespace Gallagher.LibAsn
         }
 
         [TestMethod]
-        public void EncodeSimpleSequenceOfPoints()
-        {
-            // Point with only an x coordinate of 9 like so (30 means SEQUENCE here):
-            var reference = new byte[] { 0x30, 0x06, 0x02, 0x01, 0x09, 0x02, 0x01, 0x0a };
-            var asn = AsnObject.Sequence(
-                AsnObject.Integer(new byte[] { 9 }),
-                AsnObject.Integer(new byte[] { 10 }));
-
-            var result = asn.DerEncode();
-            CollectionAssert.AreEqual(reference, result);
-        }
-
-        [TestMethod]
         public void EncodeContextSpecificSequenceOfPoints()
         {
             var asn = AsnObject.Sequence(
@@ -348,6 +335,20 @@ namespace Gallagher.LibAsn
             var d2 = AsnObject.DecodeGeneralizedTime(t2);
 
             Assert.AreEqual(new DateTime(2022, 07, 15, 6, 24, 47, DateTimeKind.Utc), d2);
+        }
+
+        [TestMethod]
+        public void EncodeUnsignedInteger()
+        {
+            uint noPaddingRequired = 1496159503; // 0x0f, 0x95, 0x2d, 0x59
+            var u1 = AsnObject.UnsignedInteger(noPaddingRequired).DerEncode();
+
+            CollectionAssert.AreEqual(new byte[] { 0x02, 0x04, 0x0f, 0x95, 0x2d, 0x59 }, u1);
+
+            uint paddingRequired = 1496159647; // 0x9f, 0x95, 0x2d, 0x59
+            var u2 = AsnObject.UnsignedInteger(paddingRequired).DerEncode();
+
+            CollectionAssert.AreEqual(new byte[] { 0x02, 0x05, 0x00, 0x9f, 0x95, 0x2d, 0x59 }, u2);
         }
 
         [TestMethod]

--- a/tests/LibAsnTests/LibAsnTests.cs
+++ b/tests/LibAsnTests/LibAsnTests.cs
@@ -137,6 +137,19 @@ namespace Gallagher.LibAsn
         }
 
         [TestMethod]
+        public void EncodeSimpleSequenceOfPoints()
+        {
+            // Point with only an x coordinate of 9 like so (30 means SEQUENCE here):
+            var reference = new byte[] { 0x30, 0x06, 0x02, 0x01, 0x09, 0x02, 0x01, 0x0a };
+            var asn = AsnObject.Sequence(
+                AsnObject.Integer(new byte[] { 9 }),
+                AsnObject.Integer(new byte[] { 10 }));
+
+            var result = asn.DerEncode();
+            CollectionAssert.AreEqual(reference, result);
+        }
+
+        [TestMethod]
         public void EncodeContextSpecificSequenceOfPoints()
         {
             var asn = AsnObject.Sequence(


### PR DESCRIPTION
This is useful for DER encoding ECDSA signatures.